### PR TITLE
DRYD-1260: Hide chronology authority

### DIFF
--- a/src/plugins/recordTypes/chronology/index.js
+++ b/src/plugins/recordTypes/chronology/index.js
@@ -1,0 +1,7 @@
+export default () => ({
+  recordTypes: {
+    chronology: {
+      disabled: true,
+    },
+  },
+});

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -1,4 +1,5 @@
 import acquisition from './acquisition';
+import chronology from './chronology';
 import collectionobject from './collectionobject';
 import concept from './concept';
 import conservation from './conservation';
@@ -17,6 +18,7 @@ import propagation from './propagation';
 
 export default [
   acquisition,
+  chronology,
   collectionobject,
   concept,
   conservation,


### PR DESCRIPTION
**What does this do?**
Disables the chronology authority

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1260

Chronology isn't being used in this profile, so it's being disabled to avoid people adding authorities which they can't use. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver: npm run devserver
* Check that the chronology authority is suppressed when selecting an authority to create

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance