### PR TITLE
Hide associated authorities for person and place

### DIFF
--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -12,6 +12,7 @@ import loanout from './loanout';
 import location from './location';
 import movement from './movement';
 import objectexit from './objectexit';
+import person from './person';
 import place from './place';
 import pottag from './pottag';
 import propagation from './propagation';
@@ -31,6 +32,7 @@ export default [
   location,
   movement,
   objectexit,
+  person,
   place,
   pottag,
   propagation,

--- a/src/plugins/recordTypes/person/forms/default.jsx
+++ b/src/plugins/recordTypes/person/forms/default.jsx
@@ -1,0 +1,218 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Col,
+    Panel,
+    Row,
+  } = configContext.layoutComponents;
+
+  const {
+    InputTable,
+    Field,
+    Subrecord,
+  } = configContext.recordComponents;
+
+  return (
+    <Field name="document">
+      <Panel name="info" collapsible>
+        <Field name="personTermGroupList">
+          <Field name="personTermGroup">
+            <Panel>
+              <Row>
+                <Field name="termDisplayName" />
+                <Field name="termName" />
+                <Field name="termQualifier" />
+                <Field name="termStatus" />
+              </Row>
+
+              <Row>
+                <Field name="termType" />
+                <Field name="termFlag" />
+                <Field name="termLanguage" />
+                <Field name="termPrefForLang" />
+              </Row>
+
+              <InputTable name="nameDetail">
+                <Field name="salutation" />
+                <Field name="title" />
+                <Field name="foreName" />
+                <Field name="middleName" />
+                <Field name="surName" />
+                <Field name="nameAdditions" />
+                <Field name="initials" />
+              </InputTable>
+
+              <InputTable name="termSource">
+                <Field name="termSource" />
+                <Field name="termSourceDetail" />
+                <Field name="termSourceID" />
+                <Field name="termSourceNote" />
+              </InputTable>
+            </Panel>
+          </Field>
+        </Field>
+
+        <Row>
+          <Col>
+            <Field name="gender" />
+
+            <Field name="occupations">
+              <Field name="occupation" />
+            </Field>
+
+            <Field name="schoolsOrStyles">
+              <Field name="schoolOrStyle" />
+            </Field>
+
+            <Field name="groups">
+              <Field name="group" />
+            </Field>
+
+            <Field name="nationalities">
+              <Field name="nationality" />
+            </Field>
+          </Col>
+          <Col>
+            <Field name="nameNote" />
+
+            <Row>
+              <Field name="birthDateGroup" />
+              <Field name="birthPlace" />
+            </Row>
+
+            <Row>
+              <Field name="deathDateGroup" />
+              <Field name="deathPlace" />
+            </Row>
+
+            <Field name="bioNote" />
+          </Col>
+        </Row>
+      </Panel>
+
+      <Subrecord name="contact" />
+
+      <Panel name="supplied" collapsible collapsed>
+        <Field name="pronounGroupList">
+          <Field name="pronounGroup">
+            <Panel>
+              <Row>
+                <Field name="declinedToAnswerPronoun" />
+                <Field name="suppliedPronouns">
+                  <Field name="suppliedPronoun" />
+                </Field>
+                <Field name="useRestrictionPronoun" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+        <Field name="genderGroupList">
+          <Field name="genderGroup">
+            <Panel>
+              <Row>
+                <Field name="declinedToAnswerGender" />
+                <Field name="suppliedGenders">
+                  <Field name="suppliedGender" />
+                </Field>
+                <Field name="useRestrictionGender" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+        <Field name="raceGroupList">
+          <Field name="raceGroup">
+            <Panel>
+              <Row>
+                <Field name="declinedToAnswerRace" />
+                <Field name="suppliedRaces">
+                  <Field name="suppliedRace" />
+                </Field>
+                <Field name="useRestrictionRace" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+        <Field name="ethnicityGroupList">
+          <Field name="ethnicityGroup">
+            <Panel>
+              <Row>
+                <Field name="declinedToAnswerEthnicity" />
+                <Field name="suppliedEthnicities">
+                  <Field name="suppliedEthnicity" />
+                </Field>
+                <Field name="useRestrictionEthnicity" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+        <Field name="sexualityGroupList">
+          <Field name="sexualityGroup">
+            <Panel>
+              <Row>
+                <Field name="declinedToAnswerSexuality" />
+                <Field name="suppliedSexualities">
+                  <Field name="suppliedSexuality" />
+                </Field>
+                <Field name="useRestrictionSexuality" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+        <Field name="birthPlaceGroupList">
+          <Field name="birthPlaceGroup">
+            <Panel>
+              <Row>
+                <Field name="declinedToAnswerBirthPlace" />
+                <Field name="suppliedBirthPlace" />
+                <Field name="useRestrictionBirthPlace" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+        <Field name="suppliedBirthDateGroupList">
+          <Field name="suppliedBirthDateGroup">
+            <Panel>
+              <Row>
+                <Field name="declinedToAnswerBirthDate" />
+                <Field name="suppliedStructuredBirthDateGroup" />
+                <Field name="useRestrictionBirthDate" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+        <Field name="otherGroupList">
+          <Field name="otherGroup">
+            <Panel>
+              <Row>
+                <Field name="informationAuthor" />
+                <Field name="informationDate" />
+                <Field name="informationUseRestriction" />
+              </Row>
+              <Field name="otherInformation" />
+            </Panel>
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="hierarchy" collapsible collapsed>
+        <Field name="relation-list-item" subpath="rel:relations-common-list" />
+      </Panel>
+
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.person.default.name',
+      defaultMessage: 'Standard Template',
+    },
+  }),
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/person/forms/default.jsx
+++ b/src/plugins/recordTypes/person/forms/default.jsx
@@ -1,5 +1,3 @@
-import { defineMessages } from 'react-intl';
-
 const template = (configContext) => {
   const {
     React,
@@ -208,11 +206,5 @@ const template = (configContext) => {
 };
 
 export default (configContext) => ({
-  messages: defineMessages({
-    name: {
-      id: 'form.person.default.name',
-      defaultMessage: 'Standard Template',
-    },
-  }),
   template: template(configContext),
 });

--- a/src/plugins/recordTypes/person/forms/index.js
+++ b/src/plugins/recordTypes/person/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});

--- a/src/plugins/recordTypes/person/index.js
+++ b/src/plugins/recordTypes/person/index.js
@@ -1,10 +1,8 @@
 import forms from './forms';
-import vocabularies from './vocabularies';
 
 export default () => (configContext) => ({
   recordTypes: {
-    place: {
-      vocabularies,
+    person: {
       forms: forms(configContext),
     },
   },

--- a/src/plugins/recordTypes/place/forms/default.jsx
+++ b/src/plugins/recordTypes/place/forms/default.jsx
@@ -1,5 +1,3 @@
-import { defineMessages } from 'react-intl';
-
 const template = (configContext) => {
   const {
     React,
@@ -160,11 +158,5 @@ const template = (configContext) => {
 };
 
 export default (configContext) => ({
-  messages: defineMessages({
-    name: {
-      id: 'form.place.default.name',
-      defaultMessage: 'Standard Template',
-    },
-  }),
   template: template(configContext),
 });

--- a/src/plugins/recordTypes/place/forms/default.jsx
+++ b/src/plugins/recordTypes/place/forms/default.jsx
@@ -1,0 +1,170 @@
+import { defineMessages } from 'react-intl';
+
+const template = (configContext) => {
+  const {
+    React,
+  } = configContext.lib;
+
+  const {
+    Panel,
+    Row,
+    Col,
+  } = configContext.layoutComponents;
+
+  const {
+    Field,
+    InputTable,
+  } = configContext.recordComponents;
+
+  const {
+    extensions,
+  } = configContext.config;
+
+  return (
+    <Field name="document">
+      <Panel name="info" collapsible>
+        <Field name="placeTermGroupList">
+          <Field name="placeTermGroup">
+            <Panel>
+              <Row>
+                <Field name="termDisplayName" />
+                <Field name="termName" />
+                <Field name="termQualifier" />
+                <Field name="termStatus" />
+              </Row>
+
+              <Row>
+                <Field name="termType" />
+                <Field name="termFlag" />
+                <Field name="historicalStatus" />
+                <Field name="termLanguage" />
+                <Field name="termPrefForLang" />
+              </Row>
+
+              <Row>
+                <Field name="nameAbbrev" />
+                <Field name="nameNote" />
+                <Field name="nameDateGroup" />
+              </Row>
+
+              <InputTable name="termSource">
+                <Field name="termSource" />
+                <Field name="termSourceDetail" />
+                <Field name="termSourceID" />
+                <Field name="termSourceNote" />
+              </InputTable>
+            </Panel>
+          </Field>
+        </Field>
+
+        <Row>
+          <Field name="placeType" />
+          <Field name="placeSource" />
+        </Row>
+
+        <Field name="placeOwnerGroupList">
+          <Field name="placeOwnerGroup">
+            <Field name="owner" />
+            <Field name="ownershipDateGroup" />
+            <Field name="ownershipNote" />
+          </Field>
+        </Field>
+
+        <Field name="placeNote" />
+
+        {extensions.address.form}
+      </Panel>
+
+      <Panel name="localityInfo" collapsible collapsed>
+        <Row>
+          <Field name="vCoordinates" />
+          <Field name="vLatitude" />
+          <Field name="vLongitude" />
+          <Field name="vCoordSys" />
+          <Field name="vSpatialReferenceSystem" />
+        </Row>
+
+        <Row>
+          <Field name="vElevation" />
+          <Field name="vDepth" />
+          <Field name="vDistanceAboveSurface" />
+          <Field name="vUnitofMeasure" />
+        </Row>
+
+        <Row>
+          <Col>
+            <Field name="minElevationInMeters" />
+            <Field name="maxElevationInMeters" />
+          </Col>
+
+          <Col>
+            <Field name="minDepthInMeters" />
+            <Field name="maxDepthInMeters" />
+          </Col>
+
+          <Col>
+            <Field name="minDistanceAboveSurfaceInMeters" />
+            <Field name="maxDistanceAboveSurfaceInMeters" />
+          </Col>
+
+          <Col />
+        </Row>
+
+        <Row>
+          <Field name="vCoordSource" />
+          <Field name="vCoordSourceRefId" />
+        </Row>
+      </Panel>
+
+      <Panel name="geoRefInfo" collapsible collapsed>
+        <Field name="placeGeoRefGroupList">
+          <Field name="placeGeoRefGroup">
+            <Panel>
+              <Row>
+                <Field name="decimalLatitude" />
+                <Field name="decimalLongitude" />
+                <Field name="geodeticDatum" />
+                <Field name="coordUncertaintyInMeters" />
+                <Field name="coordPrecision" />
+              </Row>
+
+              <Row>
+                <Field name="pointRadiusSpatialFit" />
+                <Field name="footprintWKT" />
+                <Field name="footprintSRS" />
+                <Field name="footprintSpatialFit" />
+              </Row>
+
+              <Row>
+                <Field name="geoReferencedBy" />
+                <Field name="geoRefDateGroup" />
+                <Field name="geoRefProtocol" />
+                <Field name="geoRefSource" />
+                <Field name="geoRefVerificationStatus" />
+              </Row>
+
+              <Row>
+                <Field name="geoRefRemarks" />
+                <Field name="geoRefPlaceName" />
+              </Row>
+            </Panel>
+          </Field>
+        </Field>
+      </Panel>
+
+      <Panel name="hierarchy" collapsible collapsed>
+        <Field name="relation-list-item" subpath="rel:relations-common-list" />
+      </Panel>
+    </Field>
+  );
+};
+
+export default (configContext) => ({
+  messages: defineMessages({
+    name: {
+      id: 'form.place.default.name',
+      defaultMessage: 'Standard Template',
+    },
+  }),
+  template: template(configContext),
+});

--- a/src/plugins/recordTypes/place/forms/index.js
+++ b/src/plugins/recordTypes/place/forms/index.js
@@ -1,0 +1,5 @@
+import defaultForm from './default';
+
+export default (configContext) => ({
+  default: defaultForm(configContext),
+});


### PR DESCRIPTION
**What does this do?**
* Hides the associated authorities block from the default form for person and place authorities

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1286

The associated authorities block was determined to only be needed for profiles with the chronology authority and is being hidden in others. These changes bring the default forms from cspace-ui and remove the associated authority block.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a person authority and see that the associated authorities block doesn't display
* Create a place authority add see that the associated authorities block doesn't display

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally